### PR TITLE
Fix module-library example. Update BUILD.bazel

### DIFF
--- a/hello_std_module/module-library/BUILD.bazel
+++ b/hello_std_module/module-library/BUILD.bazel
@@ -2,9 +2,10 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 cc_library(
     name = "a",
-    srcs = ["a.cc"],
+    #srcs = ["a.cc"],
     module_interfaces = ["a.cppm"],
     deps = ["@local_config_cc//:std_modules"],
+    features = ["cpp_modules"],
 )
 
 cc_binary(


### PR DESCRIPTION
The example for module-library needs two fixes:
- remove a.cc that does not exist
- add cpp_modules feature

Works on Bazel 9.0.0, but still broken on 9.1.0 (one step at a time :laughing: )